### PR TITLE
Minor fixes (Ruby Next compatibility)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-linux
 

--- a/lib/parser/prism.rb
+++ b/lib/parser/prism.rb
@@ -27,7 +27,7 @@ module Parser
     def parse(source_buffer)
       @source_buffer = source_buffer
 
-      build_ast(::Prism.parse(source_buffer.source, source_buffer.name).value)
+      build_ast(::Prism.parse(source_buffer.source).value)
     ensure
       @source_buffer = nil
     end
@@ -42,7 +42,7 @@ module Parser
     def parse_with_comments(source_buffer)
       @source_buffer = source_buffer
 
-      result = ::Prism.parse(source_buffer.source, source_buffer.name)
+      result = ::Prism.parse(source_buffer.source)
       [build_ast(result.value), build_comments(result.comments)]
     ensure
       @source_buffer = nil


### PR DESCRIPTION
Hey @kddnewton,

Thanks for your on Prism and this translator!

I've started experimenting with it in Ruby Next and encountered several minor issues (fixed in this PR, also see comments).

---

There are still some problems left in my build (see https://github.com/ruby-next/ruby-next/actions/workflows/ruby-prism-test.yml):

- Rationals with hex/binary values are not supported:

```ruby
Parser::Prism.parse("0xffr")

/opt/homebrew/lib/ruby/gems/3.2.0/gems/prism-0.18.0/lib/prism/node_ext.rb:55:in `Rational': invalid value for convert(): "0xff" (ArgumentError)

      Rational(slice.chomp("r"))
               ^^^^^^^^^^^^^^^^
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/prism-0.18.0/lib/prism/node_ext.rb:55:in `value'
        from /Users/palkan/dev/parser-prism/lib/parser/prism/compiler.rb:1223:in `visit_rational_node'
```

- Nil keyword pattern (`**nil`) is missing location information:

```ruby
Parser::Prism.parse('case i
        in **nil
        else
          true
        end'
)


/opt/homebrew/lib/ruby/gems/3.2.0/gems/parser-3.2.2.3/lib/parser/source/range.rb:211:in `join': undefined method `begin_pos' for nil:NilClass (NoMethodError)

            [@begin_pos, other.begin_pos].min,
                              ^^^^^^^^^^
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/parser-3.2.2.3/lib/parser/builders/default.rb:2115:in `keyword_map'
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/parser-3.2.2.3/lib/parser/builders/default.rb:1484:in `in_pattern'
        from /Users/palkan/dev/parser-prism/lib/parser/prism/compiler.rb:760:in `visit_in_node'
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/prism-0.18.0/lib/prism/node.rb:7876:in `accept'
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/prism-0.18.0/lib/prism/compiler.rb:34:in `block in visit_all'
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/prism-0.18.0/lib/prism/compiler.rb:34:in `map'
        from /opt/homebrew/lib/ruby/gems/3.2.0/gems/prism-0.18.0/lib/prism/compiler.rb:34:in `visit_all'
        from /Users/palkan/dev/parser-prism/lib/parser/prism/compiler.rb:308:in `visit_case_match_node'
```

Here `args.last.loc.expression` is `nil`: https://github.com/ruby-next/parser/blob/0af323526e73b3e8319e856863666e70f57838e0/lib/parser/builders/default.rb#L2117
